### PR TITLE
feat: pass command line arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@ report
 # Code Duplication - dupfinder
 dupfinder-report.*
 
-#SpecFlow Stuff
+# SpecFlow Stuff
+LivingDoc.html
 *.feature.cs
 SpecFlow/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Every release is published as nuget package [Boos.TestProcessWrapper](https://www.nuget.org/packages/Boos.TestProcessWrapper/).
 
-## [5.0.305-alpha] - 2023-05-15
+## [5.0.306-alpha] - 2023-05-15
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Every release is published as nuget package [Boos.TestProcessWrapper](https://www.nuget.org/packages/Boos.TestProcessWrapper/).
 
-## [Unreleased]
+## [5.0.304-alpha] - 2023-05-15
 
 ### Added
 
+- A boolean option "--option" can be passed to the application under test as command line argument
 - A "--key=value" pair can be passed to the application under test as command line argument
 
 ## [5.0.300-alpha] - 2023-05-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-Every release is published as nuget package
-[Boos.TestProcessWrapper](https://www.nuget.org/packages/Boos.TestProcessWrapper/).
+Every release is published as nuget package [Boos.TestProcessWrapper](https://www.nuget.org/packages/Boos.TestProcessWrapper/).
 
-## 5.0.300
+## [Unreleased]
+
+### Added
+
+- A single boolean option can be passed to the application under test as command line argument
+
+## [5.0.300-alpha] - 2023-05-10
 
 ### Added
 
 - README.md shows how to make a release
 
-## 5.0.298
+## [5.0.298-alpha] - 2023-05-09
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Every release is published as nuget package [Boos.TestProcessWrapper](https://www.nuget.org/packages/Boos.TestProcessWrapper/).
 
-## [5.0.304-alpha] - 2023-05-15
+## [5.0.305-alpha] - 2023-05-15
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Every release is published as nuget package [Boos.TestProcessWrapper](https://ww
 
 ### Added
 
-- A single boolean option can be passed to the application under test as command line argument
+- A "--key=value" pair can be passed to the application under test as command line argument
 
 ## [5.0.300-alpha] - 2023-05-10
 

--- a/TestProcessWrapper.Acceptance.Tests/Features/CustomReadinessCheck.feature
+++ b/TestProcessWrapper.Acceptance.Tests/Features/CustomReadinessCheck.feature
@@ -5,7 +5,7 @@ Feature: Custom Readiness Check
   I want the startup to be delayed until my custom readiness check is ready.
   
   Scenario: Custom readiness check
-    Given An application was wrapped into TestProcessWrapper
+    Given A long lived application was wrapped into TestProcessWrapper
     And a custom readiness check was configured 
     When the application is ready
     Then the custom readiness check was executed successfully

--- a/TestProcessWrapper.Acceptance.Tests/Features/PassCommandLineArguments.feature
+++ b/TestProcessWrapper.Acceptance.Tests/Features/PassCommandLineArguments.feature
@@ -1,0 +1,11 @@
+@PassCommandLineArgumentsToTestProcess
+Feature: Pass Command Line Arguments to Test Process
+  In order to control the behavior of the tested CLI application
+  As a test developer
+  I want to pass command line arguments to the wrapped test application.
+
+Scenario: Specify boolean flag as command line argument
+  Given An application was wrapped into TestProcessWrapper
+  And the command line argument '--help' has been configured
+  When the application is ready
+  Then the application has received the command line argument

--- a/TestProcessWrapper.Acceptance.Tests/Features/PassCommandLineArguments.feature
+++ b/TestProcessWrapper.Acceptance.Tests/Features/PassCommandLineArguments.feature
@@ -9,3 +9,9 @@ Scenario: Specify command line argument with value
   And the command line argument '--test-argument=test-argument-value' has been configured
   When the application is ready
   Then the application has received the command line argument '--test-argument' with value 'test-argument-value'
+
+Scenario: Specify boolean command line option (flag)
+  Given A short lived application was wrapped into TestProcessWrapper
+  And the command line argument '--test-argument' has been configured
+  When the application is ready
+  Then the application has received the command line argument '--test-argument'

--- a/TestProcessWrapper.Acceptance.Tests/Features/PassCommandLineArguments.feature
+++ b/TestProcessWrapper.Acceptance.Tests/Features/PassCommandLineArguments.feature
@@ -5,7 +5,7 @@ Feature: Pass Command Line Arguments to Test Process
   I want to pass command line arguments to the wrapped test application.
 
 Scenario: Specify command line argument with value
-  Given An application was wrapped into TestProcessWrapper
+  Given A long lived application was wrapped into TestProcessWrapper
   And the command line argument '--test-argument=test-argument-value' has been configured
   When the application is ready
   Then the application has received the command line argument '--test-argument' with value 'test-argument-value'

--- a/TestProcessWrapper.Acceptance.Tests/Features/PassCommandLineArguments.feature
+++ b/TestProcessWrapper.Acceptance.Tests/Features/PassCommandLineArguments.feature
@@ -4,8 +4,8 @@ Feature: Pass Command Line Arguments to Test Process
   As a test developer
   I want to pass command line arguments to the wrapped test application.
 
-Scenario: Specify boolean flag as command line argument
+Scenario: Specify command line argument with value
   Given An application was wrapped into TestProcessWrapper
-  And the command line argument '--help=true' has been configured
+  And the command line argument '--test-argument=test-argument-value' has been configured
   When the application is ready
-  Then the application has received the command line argument
+  Then the application has received the command line argument '--test-argument' with value 'test-argument-value'

--- a/TestProcessWrapper.Acceptance.Tests/Features/PassCommandLineArguments.feature
+++ b/TestProcessWrapper.Acceptance.Tests/Features/PassCommandLineArguments.feature
@@ -6,6 +6,6 @@ Feature: Pass Command Line Arguments to Test Process
 
 Scenario: Specify boolean flag as command line argument
   Given An application was wrapped into TestProcessWrapper
-  And the command line argument '--help' has been configured
+  And the command line argument '--help=true' has been configured
   When the application is ready
   Then the application has received the command line argument

--- a/TestProcessWrapper.Acceptance.Tests/Features/PassEnvironmentVariables.feature
+++ b/TestProcessWrapper.Acceptance.Tests/Features/PassEnvironmentVariables.feature
@@ -5,7 +5,7 @@ Feature: Pass Environment Variables
   I want to specify configuration parameters as environment variables
 
 Scenario: Pass Environment Variables to the Process controlled by TestProcessWrapper
-  Given An application was wrapped into TestProcessWrapper
+  Given A long lived application was wrapped into TestProcessWrapper
 	And two environment variables have been configured
 	When the application is ready
 	Then the application has received the configured environment variables

--- a/TestProcessWrapper.Acceptance.Tests/Features/PassEnvironmentVariables.feature
+++ b/TestProcessWrapper.Acceptance.Tests/Features/PassEnvironmentVariables.feature
@@ -4,7 +4,6 @@ Feature: Pass Environment Variables
   As a test developer using TestProcessWrapper
   I want to specify configuration parameters as environment variables
 
-@mytag
 Scenario: Pass Environment Variables to the Process controlled by TestProcessWrapper
   Given An application was wrapped into TestProcessWrapper
 	And two environment variables have been configured

--- a/TestProcessWrapper.Acceptance.Tests/Features/ShortLivedApplication.feature
+++ b/TestProcessWrapper.Acceptance.Tests/Features/ShortLivedApplication.feature
@@ -1,7 +1,8 @@
+@ShortLivedApplication
 Feature: Short Lived Application
 	In order to test command line interface applications (CLI)
   As a test developer
-  I want to test an applications terminating on its own after its task is complete.
+  I want to test an application terminating on its own after its task is complete.
 
 Scenario: Application shuts down after printing its process id
 	Given 1 short lived application is running with coverlet 'enabled'

--- a/TestProcessWrapper.Acceptance.Tests/Steps/Common/MultiProcessControlStepDefinitions.cs
+++ b/TestProcessWrapper.Acceptance.Tests/Steps/Common/MultiProcessControlStepDefinitions.cs
@@ -25,27 +25,6 @@ namespace TestProcessWrapper.Acceptance.Tests.Steps.Common
             GC.SuppressFinalize(this);
         }
 
-        [When(@"all applications are shut down gracefully")]
-        public static void WhenAllApplicationsAreShutDownGracefully()
-        {
-            ShutdownProcessesGracefully();
-        }
-
-        [When(@"all applications had enough time to finish")]
-        public static void WhenAllApplicationsHadEnoughTimeToFinish()
-        {
-            foreach (var client in Clients)
-            {
-                client.WaitForProcessExit();
-            }
-        }
-
-        [Then]
-        public static void ThenAllApplicationsShutDown()
-        {
-            Assert.True(Clients.All(c => c.HasExited));
-        }
-
         [Given(@"(.*) long lived application is running with coverlet '(enabled|disabled)'")]
         [Given(@"(.*) long lived applications are running with coverlet '(enabled|disabled)'")]
         public void GivenLongLivedApplicationsAreRunningWithCoverlet(
@@ -60,7 +39,6 @@ namespace TestProcessWrapper.Acceptance.Tests.Steps.Common
             Assert.True(Clients.All(c => c.IsRunning));
         }
 
-        // TODO: Sort the Given, When, Then steps in MultiProcessControlStepDefinitions
         [Given(@"(.*) short lived application is running with coverlet '(enabled|disabled)'")]
         [Given(@"(.*) short lived applications are running with coverlet '(enabled|disabled)'")]
         public void GivenShortLivedApplicationsAreRunningWithCoverlet(
@@ -71,6 +49,27 @@ namespace TestProcessWrapper.Acceptance.Tests.Steps.Common
             const string appProjectName = "TestProcessWrapper.ShortLived.Application";
 
             CreateAndStartAllApplications(numberOfClients, isCoverletEnabled, appProjectName);
+        }
+
+        [When(@"all applications had enough time to finish")]
+        public static void WhenAllApplicationsHadEnoughTimeToFinish()
+        {
+            foreach (var client in Clients)
+            {
+                client.WaitForProcessExit();
+            }
+        }
+
+        [When(@"all applications are shut down gracefully")]
+        public static void WhenAllApplicationsAreShutDownGracefully()
+        {
+            ShutdownProcessesGracefully();
+        }
+
+        [Then]
+        public static void ThenAllApplicationsShutDown()
+        {
+            Assert.True(Clients.All(c => c.HasExited));
         }
 
         private void CreateAndStartAllApplications(

--- a/TestProcessWrapper.Acceptance.Tests/Steps/Common/MultiProcessControlStepDefinitions.cs
+++ b/TestProcessWrapper.Acceptance.Tests/Steps/Common/MultiProcessControlStepDefinitions.cs
@@ -80,10 +80,7 @@ namespace TestProcessWrapper.Acceptance.Tests.Steps.Common
         {
             for (var clientIndex = 0; clientIndex < numberOfClients; clientIndex++)
             {
-                var client = new TestProcessWrapper(
-                    appProjectName,
-                    isCoverletEnabled
-                );
+                var client = new TestProcessWrapper(appProjectName, isCoverletEnabled);
                 client.TestOutputHelper = _testOutputHelper;
                 client.Start();
 

--- a/TestProcessWrapper.Acceptance.Tests/Steps/Common/MultiProcessControlStepDefinitions.cs
+++ b/TestProcessWrapper.Acceptance.Tests/Steps/Common/MultiProcessControlStepDefinitions.cs
@@ -17,7 +17,7 @@ namespace TestProcessWrapper.Acceptance.Tests.Steps.Common
         public MultiProcessControlStepDefinitions(ITestOutputHelper testOutputHelper) =>
             _testOutputHelper = testOutputHelper;
 
-        public static List<global::TestProcessWrapper.TestProcessWrapper> Clients { get; } = new();
+        public static List<TestProcessWrapper> Clients { get; } = new();
 
         public void Dispose()
         {
@@ -60,6 +60,7 @@ namespace TestProcessWrapper.Acceptance.Tests.Steps.Common
             Assert.True(Clients.All(c => c.IsRunning));
         }
 
+        // TODO: Sort the Given, When, Then steps in MultiProcessControlStepDefinitions
         [Given(@"(.*) short lived application is running with coverlet '(enabled|disabled)'")]
         [Given(@"(.*) short lived applications are running with coverlet '(enabled|disabled)'")]
         public void GivenShortLivedApplicationsAreRunningWithCoverlet(
@@ -80,7 +81,7 @@ namespace TestProcessWrapper.Acceptance.Tests.Steps.Common
         {
             for (var clientIndex = 0; clientIndex < numberOfClients; clientIndex++)
             {
-                var client = new global::TestProcessWrapper.TestProcessWrapper(
+                var client = new TestProcessWrapper(
                     appProjectName,
                     isCoverletEnabled
                 );

--- a/TestProcessWrapper.Acceptance.Tests/Steps/Common/SingleProcessControlStepDefinitions.cs
+++ b/TestProcessWrapper.Acceptance.Tests/Steps/Common/SingleProcessControlStepDefinitions.cs
@@ -50,6 +50,13 @@ namespace TestProcessWrapper.Acceptance.Tests.Steps.Common
             Client.TestOutputHelper = _testOutputHelper;
         }
 
+        [Given(@"A short lived application was wrapped into TestProcessWrapper")]
+        public void GivenAShortLivedApplicationWasWrappedIntoTestProcessWrapper()
+        {
+            Client = new TestProcessWrapper("TestProcessWrapper.ShortLived.Application", false);
+            Client.TestOutputHelper = _testOutputHelper;
+        }
+
         [When]
         public static void WhenTheApplicationIsReady()
         {

--- a/TestProcessWrapper.Acceptance.Tests/Steps/Common/SingleProcessControlStepDefinitions.cs
+++ b/TestProcessWrapper.Acceptance.Tests/Steps/Common/SingleProcessControlStepDefinitions.cs
@@ -43,8 +43,8 @@ namespace TestProcessWrapper.Acceptance.Tests.Steps.Common
             _isDisposed = true;
         }
 
-        [Given(@"An application was wrapped into TestProcessWrapper")]
-        public void GivenAnApplicationWasWrappedIntoTestProcessWrapper()
+        [Given(@"A long lived application was wrapped into TestProcessWrapper")]
+        public void GivenALongLivedApplicationWasWrappedIntoTestProcessWrapper()
         {
             Client = new TestProcessWrapper("TestProcessWrapper.LongLived.Application", false);
             Client.TestOutputHelper = _testOutputHelper;

--- a/TestProcessWrapper.Acceptance.Tests/Steps/PassCommandLineArgumentsStepDefinitions.cs
+++ b/TestProcessWrapper.Acceptance.Tests/Steps/PassCommandLineArgumentsStepDefinitions.cs
@@ -9,7 +9,7 @@ public class StepDefinitions
 {
     private string _outputWhenReady;
 
-    [Given(@"the command line argument '(.*)=(.*)' has been configured")]
+    [Given(@"the command line argument '([-a-zA-Z0-9]*)=([-a-zA-Z0-9]*)' has been configured")]
     public void GivenTheCommandLineArgumentHasBeenConfigured(string argument, string value)
     {
         var client = SingleProcessControlStepDefinitions.Client;
@@ -21,9 +21,27 @@ public class StepDefinitions
         });
     }
 
-    [Then(@"the application has received the command line argument '(.*)' with value '(.*)'")]
+    [Given(@"the command line argument '([-a-zA-Z0-9]*)' has been configured")]
+    public void GivenTheCommandLineArgumentHasBeenConfigured(string argument)
+    {
+        var client = SingleProcessControlStepDefinitions.Client;
+        client.AddCommandLineArgument(argument);
+        client.AddReadinessCheck(output =>
+        {
+            _outputWhenReady = output;
+            return true;
+        });
+    }
+
+    [Then(@"the application has received the command line argument '([-a-zA-Z0-9]*)' with value '([-a-zA-Z0-9]*)'")]
     public void ThenTheApplicationHasReceivedTheCommandLineArgumentWithValue(string argument, string value)
     {
         Assert.Contains($"Received the command line argument '{argument}={value}'", _outputWhenReady);
+    }
+
+    [Then(@"the application has received the command line argument '([-a-zA-Z0-9]*)'")]
+    public void ThenTheApplicationHasReceivedTheCommandLineArgument(string argument)
+    {
+        Assert.Contains($"Received the command line argument '{argument}'", _outputWhenReady);
     }
 }

--- a/TestProcessWrapper.Acceptance.Tests/Steps/PassCommandLineArgumentsStepDefinitions.cs
+++ b/TestProcessWrapper.Acceptance.Tests/Steps/PassCommandLineArgumentsStepDefinitions.cs
@@ -1,0 +1,23 @@
+using TechTalk.SpecFlow;
+
+namespace TestProcessWrapper.Acceptance.Tests.Steps;
+
+[Binding]
+public class StepDefinitions
+{
+    private readonly ScenarioContext _scenarioContext;
+
+    public StepDefinitions(ScenarioContext scenarioContext) => _scenarioContext = scenarioContext;
+
+    [Given(@"the command line argument '(.*)' has been configured")]
+    public void GivenTheCommandLineArgumentHasBeenConfigured(string commandLineArgument)
+    {
+        _scenarioContext.Pending();
+    }
+
+    [Then(@"the application has received the command line argument")]
+    public void ThenTheApplicationHasReceivedTheCommandLineArgument(string expectedPhrase)
+    {
+        _scenarioContext.Pending();
+    }
+}

--- a/TestProcessWrapper.Acceptance.Tests/Steps/PassCommandLineArgumentsStepDefinitions.cs
+++ b/TestProcessWrapper.Acceptance.Tests/Steps/PassCommandLineArgumentsStepDefinitions.cs
@@ -7,9 +7,10 @@ namespace TestProcessWrapper.Acceptance.Tests.Steps;
 [Binding]
 public class StepDefinitions
 {
+    private const string AllowedCharactersForArgument = "[-a-zA-Z0-9]*";
     private string _outputWhenReady;
 
-    [Given(@"the command line argument '([-a-zA-Z0-9]*)=([-a-zA-Z0-9]*)' has been configured")]
+    [Given($"the command line argument '({AllowedCharactersForArgument})=({AllowedCharactersForArgument})' has been configured")]
     public void GivenTheCommandLineArgumentHasBeenConfigured(string argument, string value)
     {
         var client = SingleProcessControlStepDefinitions.Client;
@@ -21,7 +22,7 @@ public class StepDefinitions
         });
     }
 
-    [Given(@"the command line argument '([-a-zA-Z0-9]*)' has been configured")]
+    [Given($"the command line argument '({AllowedCharactersForArgument})' has been configured")]
     public void GivenTheCommandLineArgumentHasBeenConfigured(string argument)
     {
         var client = SingleProcessControlStepDefinitions.Client;
@@ -33,13 +34,13 @@ public class StepDefinitions
         });
     }
 
-    [Then(@"the application has received the command line argument '([-a-zA-Z0-9]*)' with value '([-a-zA-Z0-9]*)'")]
+    [Then($"the application has received the command line argument '({AllowedCharactersForArgument})' with value '({AllowedCharactersForArgument})'")]
     public void ThenTheApplicationHasReceivedTheCommandLineArgumentWithValue(string argument, string value)
     {
         Assert.Contains($"Received the command line argument '{argument}={value}'", _outputWhenReady);
     }
 
-    [Then(@"the application has received the command line argument '([-a-zA-Z0-9]*)'")]
+    [Then($"the application has received the command line argument '({AllowedCharactersForArgument})'")]
     public void ThenTheApplicationHasReceivedTheCommandLineArgument(string argument)
     {
         Assert.Contains($"Received the command line argument '{argument}'", _outputWhenReady);

--- a/TestProcessWrapper.Acceptance.Tests/Steps/PassCommandLineArgumentsStepDefinitions.cs
+++ b/TestProcessWrapper.Acceptance.Tests/Steps/PassCommandLineArgumentsStepDefinitions.cs
@@ -10,7 +10,9 @@ public class StepDefinitions
     private const string AllowedCharactersForArgument = "[-a-zA-Z0-9]*";
     private string _outputWhenReady;
 
-    [Given($"the command line argument '({AllowedCharactersForArgument})=({AllowedCharactersForArgument})' has been configured")]
+    [Given(
+        $"the command line argument '({AllowedCharactersForArgument})=({AllowedCharactersForArgument})' has been configured"
+    )]
     public void GivenTheCommandLineArgumentHasBeenConfigured(string argument, string value)
     {
         var client = SingleProcessControlStepDefinitions.Client;
@@ -26,13 +28,23 @@ public class StepDefinitions
         client.AddReadinessCheck(CaptureOutput);
     }
 
-    [Then($"the application has received the command line argument '({AllowedCharactersForArgument})' with value '({AllowedCharactersForArgument})'")]
-    public void ThenTheApplicationHasReceivedTheCommandLineArgumentWithValue(string argument, string value)
+    [Then(
+        $"the application has received the command line argument '({AllowedCharactersForArgument})' with value '({AllowedCharactersForArgument})'"
+    )]
+    public void ThenTheApplicationHasReceivedTheCommandLineArgumentWithValue(
+        string argument,
+        string value
+    )
     {
-        Assert.Contains($"Received the command line argument '{argument}={value}'", _outputWhenReady);
+        Assert.Contains(
+            $"Received the command line argument '{argument}={value}'",
+            _outputWhenReady
+        );
     }
 
-    [Then($"the application has received the command line argument '({AllowedCharactersForArgument})'")]
+    [Then(
+        $"the application has received the command line argument '({AllowedCharactersForArgument})'"
+    )]
     public void ThenTheApplicationHasReceivedTheCommandLineArgument(string argument)
     {
         Assert.Contains($"Received the command line argument '{argument}'", _outputWhenReady);

--- a/TestProcessWrapper.Acceptance.Tests/Steps/PassCommandLineArgumentsStepDefinitions.cs
+++ b/TestProcessWrapper.Acceptance.Tests/Steps/PassCommandLineArgumentsStepDefinitions.cs
@@ -9,11 +9,11 @@ public class StepDefinitions
 {
     private string _outputWhenReady;
 
-    [Given(@"the command line argument '(.*)' has been configured")]
-    public void GivenTheCommandLineArgumentHasBeenConfigured(string commandLineArgument)
+    [Given(@"the command line argument '(.*)=(.*)' has been configured")]
+    public void GivenTheCommandLineArgumentHasBeenConfigured(string argument, string value)
     {
         var client = SingleProcessControlStepDefinitions.Client;
-        client.AddCommandLineArgument(commandLineArgument);
+        client.AddCommandLineArgument(argument, value);
         client.AddReadinessCheck(output =>
         {
             _outputWhenReady = output;
@@ -24,6 +24,6 @@ public class StepDefinitions
     [Then(@"the application has received the command line argument")]
     public void ThenTheApplicationHasReceivedTheCommandLineArgument()
     {
-        Assert.Contains("Received the command line argument '--help'", _outputWhenReady);
+        Assert.Contains("Received the command line argument '--help=true'", _outputWhenReady);
     }
 }

--- a/TestProcessWrapper.Acceptance.Tests/Steps/PassCommandLineArgumentsStepDefinitions.cs
+++ b/TestProcessWrapper.Acceptance.Tests/Steps/PassCommandLineArgumentsStepDefinitions.cs
@@ -15,11 +15,7 @@ public class StepDefinitions
     {
         var client = SingleProcessControlStepDefinitions.Client;
         client.AddCommandLineArgument(argument, value);
-        client.AddReadinessCheck(output =>
-        {
-            _outputWhenReady = output;
-            return true;
-        });
+        client.AddReadinessCheck(CaptureOutput);
     }
 
     [Given($"the command line argument '({AllowedCharactersForArgument})' has been configured")]
@@ -27,11 +23,7 @@ public class StepDefinitions
     {
         var client = SingleProcessControlStepDefinitions.Client;
         client.AddCommandLineArgument(argument);
-        client.AddReadinessCheck(output =>
-        {
-            _outputWhenReady = output;
-            return true;
-        });
+        client.AddReadinessCheck(CaptureOutput);
     }
 
     [Then($"the application has received the command line argument '({AllowedCharactersForArgument})' with value '({AllowedCharactersForArgument})'")]
@@ -44,5 +36,11 @@ public class StepDefinitions
     public void ThenTheApplicationHasReceivedTheCommandLineArgument(string argument)
     {
         Assert.Contains($"Received the command line argument '{argument}'", _outputWhenReady);
+    }
+
+    private bool CaptureOutput(string output)
+    {
+        _outputWhenReady = output;
+        return true;
     }
 }

--- a/TestProcessWrapper.Acceptance.Tests/Steps/PassCommandLineArgumentsStepDefinitions.cs
+++ b/TestProcessWrapper.Acceptance.Tests/Steps/PassCommandLineArgumentsStepDefinitions.cs
@@ -21,9 +21,9 @@ public class StepDefinitions
         });
     }
 
-    [Then(@"the application has received the command line argument")]
-    public void ThenTheApplicationHasReceivedTheCommandLineArgument()
+    [Then(@"the application has received the command line argument '(.*)' with value '(.*)'")]
+    public void ThenTheApplicationHasReceivedTheCommandLineArgumentWithValue(string argument, string value)
     {
-        Assert.Contains("Received the command line argument '--help=true'", _outputWhenReady);
+        Assert.Contains($"Received the command line argument '{argument}={value}'", _outputWhenReady);
     }
 }

--- a/TestProcessWrapper.Acceptance.Tests/Steps/PassCommandLineArgumentsStepDefinitions.cs
+++ b/TestProcessWrapper.Acceptance.Tests/Steps/PassCommandLineArgumentsStepDefinitions.cs
@@ -1,23 +1,29 @@
 using TechTalk.SpecFlow;
+using TestProcessWrapper.Acceptance.Tests.Steps.Common;
+using Xunit;
 
 namespace TestProcessWrapper.Acceptance.Tests.Steps;
 
 [Binding]
 public class StepDefinitions
 {
-    private readonly ScenarioContext _scenarioContext;
-
-    public StepDefinitions(ScenarioContext scenarioContext) => _scenarioContext = scenarioContext;
+    private string _outputWhenReady;
 
     [Given(@"the command line argument '(.*)' has been configured")]
     public void GivenTheCommandLineArgumentHasBeenConfigured(string commandLineArgument)
     {
-        _scenarioContext.Pending();
+        var client = SingleProcessControlStepDefinitions.Client;
+        client.AddCommandLineArgument(commandLineArgument);
+        client.AddReadinessCheck(output =>
+        {
+            _outputWhenReady = output;
+            return true;
+        });
     }
 
     [Then(@"the application has received the command line argument")]
-    public void ThenTheApplicationHasReceivedTheCommandLineArgument(string expectedPhrase)
+    public void ThenTheApplicationHasReceivedTheCommandLineArgument()
     {
-        _scenarioContext.Pending();
+        Assert.Contains("Received the command line argument '--help'", _outputWhenReady);
     }
 }

--- a/TestProcessWrapper.LongLived.Application/LoggerExtensions.cs
+++ b/TestProcessWrapper.LongLived.Application/LoggerExtensions.cs
@@ -72,4 +72,14 @@ internal static class LoggerExtensions
 
     public static void ConfiguredEnvironmentVariable(this ILogger logger, string value) =>
         ConfiguredEnvironmentVariableAction(logger, value, null);
+
+    private static readonly Action<ILogger, string, string, Exception> CommandLineArgumentAction =
+        LoggerMessage.Define<string, string>(
+            LogLevel.Information,
+            new EventId(8, nameof(CommandLineArgument)),
+            "Received the command line argument '{Argument}={Value}'"
+        );
+
+    public static void CommandLineArgument(this ILogger logger, string argument, string value) =>
+        CommandLineArgumentAction(logger, argument, value, null);
 }

--- a/TestProcessWrapper.LongLived.Application/Program.cs
+++ b/TestProcessWrapper.LongLived.Application/Program.cs
@@ -5,11 +5,11 @@ namespace TestProcessWrapper.LongLived.Application
 {
     public static class Program
     {
-        public static void Main()
+        public static void Main(string[] args)
         {
             try
             {
-                SimpleHostBuilder.Create<SimpleService>().Build().Run();
+                SimpleHostBuilder.Create<SimpleService>(args).Build().Run();
             }
             catch (Exception e)
             {

--- a/TestProcessWrapper.LongLived.Application/SimpleHostBuilder.cs
+++ b/TestProcessWrapper.LongLived.Application/SimpleHostBuilder.cs
@@ -9,10 +9,10 @@ namespace TestProcessWrapper.LongLived.Application
         public static IHostBuilder Create<
             [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)]
                 THostedService
-        >()
+        >(string[] args)
             where THostedService : class, IHostedService
         {
-            return Host.CreateDefaultBuilder()
+            return Host.CreateDefaultBuilder(args)
                 .ConfigureServices(
                     (_, services) =>
                         services

--- a/TestProcessWrapper.LongLived.Application/SimpleService.cs
+++ b/TestProcessWrapper.LongLived.Application/SimpleService.cs
@@ -26,7 +26,7 @@ namespace TestProcessWrapper.LongLived.Application
 
                 while (true)
                 {
-                    await ExecuteSensorLoopBody(stoppingToken);
+                    await PerformSampleWorkerTask(stoppingToken);
                 }
             }
             catch (OperationCanceledException)
@@ -51,7 +51,7 @@ namespace TestProcessWrapper.LongLived.Application
             stoppingToken.ThrowIfCancellationRequested();
         }
 
-        private async Task ExecuteSensorLoopBody(CancellationToken stoppingToken)
+        private async Task PerformSampleWorkerTask(CancellationToken stoppingToken)
         {
             await Task.Delay(DelayAfterEachLoop, stoppingToken);
         }

--- a/TestProcessWrapper.LongLived.Application/SimpleService.cs
+++ b/TestProcessWrapper.LongLived.Application/SimpleService.cs
@@ -1,19 +1,23 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace TestProcessWrapper.LongLived.Application
 {
-    public class SimpleService : BackgroundService
+    public sealed class SimpleService : BackgroundService
     {
-        public SimpleService(ILogger<SimpleService> logger) => Logger = logger;
-
         private ILogger<SimpleService> Logger { get; }
 
         private TimeSpan DelayAfterEachLoop { get; } = TimeSpan.FromMilliseconds(50.0);
 
+        public SimpleService(ILogger<SimpleService> logger, IConfiguration configuration)
+        {
+            Logger = logger;
+            Logger.CommandLineArgument("--help", configuration.GetValue<bool>("help").ToString().ToLowerInvariant());
+        }
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             try
@@ -47,7 +51,7 @@ namespace TestProcessWrapper.LongLived.Application
             stoppingToken.ThrowIfCancellationRequested();
         }
 
-        protected virtual async Task ExecuteSensorLoopBody(CancellationToken stoppingToken)
+        private async Task ExecuteSensorLoopBody(CancellationToken stoppingToken)
         {
             await Task.Delay(DelayAfterEachLoop, stoppingToken);
         }

--- a/TestProcessWrapper.LongLived.Application/SimpleService.cs
+++ b/TestProcessWrapper.LongLived.Application/SimpleService.cs
@@ -16,8 +16,12 @@ namespace TestProcessWrapper.LongLived.Application
         public SimpleService(ILogger<SimpleService> logger, IConfiguration configuration)
         {
             Logger = logger;
-            Logger.CommandLineArgument("--help", configuration.GetValue<bool>("help").ToString().ToLowerInvariant());
+
+            const string testArgumentName = "test-argument";
+            var testArgumentValue = configuration.GetValue<string>(testArgumentName);
+            Logger.CommandLineArgument($"--{testArgumentName}", testArgumentValue);
         }
+
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             try

--- a/TestProcessWrapper.ShortLived.Application/Program.cs
+++ b/TestProcessWrapper.ShortLived.Application/Program.cs
@@ -1,5 +1,9 @@
 ﻿// error CA1852: Type 'Program' can be sealed because it has no subtypes in its containing assembly and is not externally visible
 #pragma warning disable CA1852
 Console.WriteLine($"Process ID {Environment.ProcessId}");
+if (args.Contains("--test-argument"))
+{
+    Console.WriteLine($"Received the command line argument '--test-argument'");
+}
 Console.WriteLine($"Shut down");
 #pragma warning restore CA1852

--- a/TestProcessWrapper.sln
+++ b/TestProcessWrapper.sln
@@ -20,6 +20,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "misc", "misc", "{86E95D10-0
 		run-application.bat = run-application.bat
 		run-application.sh = run-application.sh
 		Nuget-OfficialOnly.config = Nuget-OfficialOnly.config
+		CHANGELOG.md = CHANGELOG.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestProcessWrapper.LongLived.Application", "TestProcessWrapper.LongLived.Application\TestProcessWrapper.LongLived.Application.csproj", "{5122B0AC-FAD4-44F4-B372-C5A6AED29E22}"

--- a/TestProcessWrapper/DotnetProcess.cs
+++ b/TestProcessWrapper/DotnetProcess.cs
@@ -16,6 +16,9 @@ internal sealed class DotnetProcess : IProcess
         set => _process.StartInfo = value;
     }
 
+    public void AddCommandLineArgument(string argument, string value) =>
+        _process.StartInfo.Arguments += $" {argument}={value}";
+
     public void AddEnvironmentVariable(string name, string value) =>
         _process.StartInfo.EnvironmentVariables.Add(name, value);
 

--- a/TestProcessWrapper/DotnetProcess.cs
+++ b/TestProcessWrapper/DotnetProcess.cs
@@ -17,7 +17,7 @@ internal sealed class DotnetProcess : IProcess
     }
 
     public void AddCommandLineArgument(string argument, string value) =>
-        _process.StartInfo.Arguments += $" {argument}={value}";
+        _process.StartInfo.Arguments += string.IsNullOrEmpty(value) ? $" {argument}" : $" {argument}={value}";
 
     public void AddEnvironmentVariable(string name, string value) =>
         _process.StartInfo.EnvironmentVariables.Add(name, value);

--- a/TestProcessWrapper/DotnetProcess.cs
+++ b/TestProcessWrapper/DotnetProcess.cs
@@ -17,7 +17,9 @@ internal sealed class DotnetProcess : IProcess
     }
 
     public void AddCommandLineArgument(string argument, string value) =>
-        _process.StartInfo.Arguments += string.IsNullOrEmpty(value) ? $" {argument}" : $" {argument}={value}";
+        _process.StartInfo.Arguments += string.IsNullOrEmpty(value)
+            ? $" {argument}"
+            : $" {argument}={value}";
 
     public void AddEnvironmentVariable(string name, string value) =>
         _process.StartInfo.EnvironmentVariables.Add(name, value);

--- a/TestProcessWrapper/IProcess.cs
+++ b/TestProcessWrapper/IProcess.cs
@@ -9,6 +9,8 @@ namespace TestProcessWrapper
 
         ProcessStartInfo StartInfo { get; }
 
+        void AddCommandLineArgument(string argument, string value);
+
         void AddEnvironmentVariable(string name, string value);
 
         void Start();

--- a/TestProcessWrapper/TestProcessWrapper.cs
+++ b/TestProcessWrapper/TestProcessWrapper.cs
@@ -78,7 +78,7 @@ public sealed class TestProcessWrapper : IDisposable
     // TODO: Implement TestProcessWrapper.AddCommandLineArgument and remove static analysis suppression
     // ReSharper disable once MemberCanBeMadeStatic.Global
     [SuppressMessage("Performance", "CA1822:Member als statisch markieren")]
-    public void AddCommandLineArgument(string commandLineArgument)
+    public void AddCommandLineArgument(string argument, string value)
     {
     }
 

--- a/TestProcessWrapper/TestProcessWrapper.cs
+++ b/TestProcessWrapper/TestProcessWrapper.cs
@@ -77,12 +77,7 @@ public sealed class TestProcessWrapper : IDisposable
         _environmentVariables[name] = value;
     }
 
-    public void AddCommandLineArgument(string argument)
-    {
-        _arguments.Add(argument, "");
-    }
-
-    public void AddCommandLineArgument(string argument, string value)
+    public void AddCommandLineArgument(string argument, string value = "")
     {
         _arguments[argument] = value;
     }

--- a/TestProcessWrapper/TestProcessWrapper.cs
+++ b/TestProcessWrapper/TestProcessWrapper.cs
@@ -77,6 +77,11 @@ public sealed class TestProcessWrapper : IDisposable
         _environmentVariables[name] = value;
     }
 
+    public void AddCommandLineArgument(string argument)
+    {
+        _arguments.Add(argument, "");
+    }
+
     public void AddCommandLineArgument(string argument, string value)
     {
         _arguments[argument] = value;

--- a/TestProcessWrapper/TestProcessWrapper.cs
+++ b/TestProcessWrapper/TestProcessWrapper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using Xunit.Abstractions;
@@ -72,6 +73,13 @@ public sealed class TestProcessWrapper : IDisposable
     public void AddEnvironmentVariable(string name, string value)
     {
         _environmentVariables[name] = value;
+    }
+
+    // TODO: Implement TestProcessWrapper.AddCommandLineArgument and remove static analysis suppression
+    // ReSharper disable once MemberCanBeMadeStatic.Global
+    [SuppressMessage("Performance", "CA1822:Member als statisch markieren")]
+    public void AddCommandLineArgument(string commandLineArgument)
+    {
     }
 
     public void AddReadinessCheck(ReadinessCheck readinessCheck)


### PR DESCRIPTION
- A boolean option "--option" can be passed to the application under test as command line argument
- A "--key=value" pair can be passed to the application under test as command line argument