### PR TITLE
Add support for net8.0 while keeping support for net6.0 and net7.0

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -146,7 +146,7 @@ jobs:
           path: coverage-reports
           
       - name: Publish coverage report to coveralls.io
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: coverage-reports/lcov.info

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   RETENTION_DAYS: 5
-  packageVersionPrefix: ${{ '6.2.' }}
+  packageVersionPrefix: ${{ '6.3.' }}
   packageVersionSuffixForFeatureBranch: ${{ '-alpha' }}
   packageVersionSuffixForMainBranch: ${{ '-alpha' }}
 
@@ -32,7 +32,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 7.x
+          dotnet-version: 8.x
 
       - name: Install dotnet global tools (coverlet, reportgenerator)
         run: |
@@ -64,7 +64,7 @@ jobs:
         
       - name: Generate SpecFlow LivingDoc
         run: livingdoc test-assembly TestProcessWrapper.Acceptance.Tests.dll -t TestExecution.json
-        working-directory: TestProcessWrapper.Acceptance.Tests/bin/Debug/net7.0
+        working-directory: TestProcessWrapper.Acceptance.Tests/bin/Debug/net8.0
 
       - name: Attach NuGet package to build artifacts
         uses: actions/upload-artifact@v4
@@ -84,7 +84,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: LivingDoc
-          path: TestProcessWrapper.Acceptance.Tests/bin/Debug/net7.0/LivingDoc.html
+          path: TestProcessWrapper.Acceptance.Tests/bin/Debug/net8.0/LivingDoc.html
 
   smoketest:
     name: Test NuGet package
@@ -97,6 +97,7 @@ jobs:
         dotnet:
           - { setupVersion: 6.x, binFolder: net6.0 }
           - { setupVersion: 7.x, binFolder: net7.0 }
+          - { setupVersion: 8.x, binFolder: net8.0 }
 
     runs-on: ${{ matrix.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Every release is published as nuget package [Boos.TestProcessWrapper](https://www.nuget.org/packages/Boos.TestProcessWrapper/).
 
+## [Unreleased]
+
+### Changed
+
+- Upgrade coveralls build action to v2
+
 ## [6.2.373-alpha] - 2024-08-06
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ Every release is published as nuget package [Boos.TestProcessWrapper](https://ww
 
 ### Changed
 
+- Fix new .NET 8 static analysis warnings regarding performance of string operations
+  - CA1865: Use 'string.Method(char)' instead of 'string.Method(string)' for string with single char
+  - CA1862: Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
 - Upgrade coveralls build action to v2
 
 ## [6.2.373-alpha] - 2024-08-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Every release is published as nuget package [Boos.TestProcessWrapper](https://www.nuget.org/packages/Boos.TestProcessWrapper/).
 
-## [Unreleased]
+## [6.3.376-alpha] - 2024-08-07
+
+### Added
+
+- Add support for net8.0 while keeping support for net6.0 and net7.0
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -92,10 +92,14 @@ an [Open Source License](https://www.jetbrains.com/community/opensource/) for th
 
 ### Prerequisites
 
-To compile, test and run this project the latest [.NET SDK](https://dotnet.microsoft.com/download) is required on
-your machine. For calculating code metrics I recommend [metrix++](https://github.com/metrixplusplus/metrixplusplus).
-This requires [Python](https://www.python.org/). If you'd like to contribute, then please use the
-[dotnet csharpier .](https://csharpier.com/) command as described below.
+To compile, test and run this project the [.NET SDK](https://dotnet.microsoft.com/download) is required on your machine.
+The project supports .NET 6.0, .NET 7.0 and .NET 8.0.
+
+For calculating code metrics I recommend [metrix++](https://github.com/metrixplusplus/metrixplusplus).
+This requires [Python](https://www.python.org/).
+
+If you'd like to contribute, then please use the [dotnet csharpier .](https://csharpier.com/) command as described
+below.
 
 To use the `TestProcessWrapper` library and to run the unit tests you need the following tools installed:
 
@@ -104,7 +108,7 @@ dotnet tool install --global coverlet.console --configfile NuGet-OfficialOnly.co
 dotnet tool install --global dotnet-reportgenerator-globaltool --configfile NuGet-OfficialOnly.config
 ```
 
-### Troubleshooting
+### Troubleshooting the Installation of dotnet tools
 
 If you are installing a dotnet tool for the first time, then you'll need to add the path to the dotnet tools to your
 system PATH. Please make sure that there is no "~" character in your PATH to coverlet.
@@ -124,6 +128,12 @@ run the application:
 
 Note: The script [build.sh](./build/build.sh) builds the NuGet package like the build pipeline does it. This can be helpful
 when debugging issues popping up in the build pipeline.
+
+Important: The acceptance tests require both a debug and a release build of the long lived application.
+
+```sh
+
+To build the solution and run the acceptance tests manually, issue the following console commands:
 
 ```sh
 # Remove build output from previous runs
@@ -162,7 +172,10 @@ You can replace the "net8.0" with "net7.0" or "net6.0", if you want to test a di
 
 #### Create Feature Documentation (LivingDoc)
 
-As this project uses SpecFlow for acceptance tests, you can generate an HTML overview of all features including the test status as follows:
+As this project uses SpecFlow for acceptance tests, you can generate an HTML overview of all features including the test
+status as follows.
+
+Note: Despite the warnings, the commands produce correct documentation when using .NET 8.
 
 ```shell
 # Prerequisite: Install the LivingDoc CLI once

--- a/README.md
+++ b/README.md
@@ -155,10 +155,10 @@ dotnet pack --configuration Debug TestProcessWrapper/TestProcessWrapper.csproj
 
 # run the smoke tests
 cd TestProcessWrapper.Nupkg.Tests
-./smoketest.sh "net7.0"
+./smoketest.sh "net8.0"
 ```
 
-You can replace the "net7.0" parameter with "net6.0", if you want to test that version of the .net framework.
+You can replace the "net8.0" with "net7.0" or "net6.0", if you want to test a different version of the .net framework.
 
 #### Create Feature Documentation (LivingDoc)
 
@@ -175,12 +175,12 @@ dotnet tool install --global SpecFlow.Plus.LivingDoc.CLI
 dotnet test TestProcessWrapper.Acceptance.Tests
 
 # Generate LivingDoc
-cd TestProcessWrapper.Acceptance.Tests/bin/Debug/net7.0
+cd TestProcessWrapper.Acceptance.Tests/bin/Debug/net8.0
 livingdoc test-assembly TestProcessWrapper.Acceptance.Tests.dll -t TestExecution.json
 cd ../../../..
 
 # Open the generated HTML in a browser
-open TestProcessWrapper.Acceptance.Tests/bin/Debug/net7.0/LivingDoc.html
+open TestProcessWrapper.Acceptance.Tests/bin/Debug/net8.0/LivingDoc.html
 ```
 
 #### Before Creating a Pull Request ...

--- a/TestProcessWrapper.Acceptance.Tests/Steps/Common/StepArgumentTransformations.cs
+++ b/TestProcessWrapper.Acceptance.Tests/Steps/Common/StepArgumentTransformations.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+using System;
 using TechTalk.SpecFlow;
 
 namespace TestProcessWrapper.Acceptance.Tests.Steps.Common
@@ -8,13 +8,13 @@ namespace TestProcessWrapper.Acceptance.Tests.Steps.Common
     {
         [StepArgumentTransformation(@"(enabled|disabled)")]
         public static bool TransformHumanReadableBooleanSwitchExpression(string expression) =>
-            "ENABLED" == expression.ToUpper(CultureInfo.CurrentCulture);
+            expression.Equals("enabled", StringComparison.OrdinalIgnoreCase);
 
         [StepArgumentTransformation(@"(Debug|Release)")]
         public static BuildConfiguration TransformHumanReadableBuildConfiguration(
             string buildConfiguration
         ) =>
-            "RELEASE" == buildConfiguration.ToUpperInvariant()
+            buildConfiguration.Equals("Release", StringComparison.OrdinalIgnoreCase)
                 ? BuildConfiguration.Release
                 : BuildConfiguration.Debug;
     }

--- a/TestProcessWrapper.Acceptance.Tests/Steps/Common/ValidateCoverageStepDefinitions.cs
+++ b/TestProcessWrapper.Acceptance.Tests/Steps/Common/ValidateCoverageStepDefinitions.cs
@@ -35,8 +35,8 @@ public partial class ValidateCoverageStepDefinitions
     {
         var comparison = GetComparisonByName(comparisonString);
 
-        var clientsWithCoverlet = MultiProcessControlStepDefinitions.Clients.Where(
-            c => c.IsCoverletEnabled
+        var clientsWithCoverlet = MultiProcessControlStepDefinitions.Clients.Where(c =>
+            c.IsCoverletEnabled
         );
         foreach (var client in clientsWithCoverlet)
         {

--- a/TestProcessWrapper.Acceptance.Tests/TestProcessWrapper.Acceptance.Tests.csproj
+++ b/TestProcessWrapper.Acceptance.Tests/TestProcessWrapper.Acceptance.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/TestProcessWrapper.LongLived.Application/TestProcessWrapper.LongLived.Application.csproj
+++ b/TestProcessWrapper.LongLived.Application/TestProcessWrapper.LongLived.Application.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/TestProcessWrapper.Nupkg.Tests/net8.0-global.json
+++ b/TestProcessWrapper.Nupkg.Tests/net8.0-global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestMinor"
+  }
+}

--- a/TestProcessWrapper.Nupkg.Tests/smoketest.sh
+++ b/TestProcessWrapper.Nupkg.Tests/smoketest.sh
@@ -4,9 +4,9 @@
 #
 # USAGE: ./smoketest.sh FRAMEWORK_VERSION
 #
-# The parameter FRAMEWORK_VERSION ($1) can be either "net6.0" or "net7.0".
+# The parameter FRAMEWORK_VERSION ($1) can be either "net6.0", "net7.0" or "net8.0".
 #
-set -euf
+set -euxf
 
 #####
 # Parse parameters
@@ -43,9 +43,9 @@ rm -vfr "TestProcessWrapper.ShortLived.Application/obj"
 
 if [ "$(uname)" = "Darwin" ]; then
   # on macOS, the sed -i parameter requires empty single quotes
-  sed -i '' "s/net7.0/${framework_version}/" "TestProcessWrapper.ShortLived.Application/TestProcessWrapper.ShortLived.Application.csproj"
+  sed -i '' "s/net8.0/${framework_version}/" "TestProcessWrapper.ShortLived.Application/TestProcessWrapper.ShortLived.Application.csproj"
 else
-  sed -i "s/net7.0/${framework_version}/" "TestProcessWrapper.ShortLived.Application/TestProcessWrapper.ShortLived.Application.csproj"
+  sed -i "s/net8.0/${framework_version}/" "TestProcessWrapper.ShortLived.Application/TestProcessWrapper.ShortLived.Application.csproj"
 fi
 
 dotnet build --configuration Debug "TestProcessWrapper.ShortLived.Application/TestProcessWrapper.ShortLived.Application.csproj"

--- a/TestProcessWrapper.ShortLived.Application/TestProcessWrapper.ShortLived.Application.csproj
+++ b/TestProcessWrapper.ShortLived.Application/TestProcessWrapper.ShortLived.Application.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
     </PropertyGroup>

--- a/TestProcessWrapper.Unit.Tests/TestProcessWrapper.Unit.Tests.csproj
+++ b/TestProcessWrapper.Unit.Tests/TestProcessWrapper.Unit.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/TestProcessWrapper.Unit.Tests/TestProcessWrapperTest.cs
+++ b/TestProcessWrapper.Unit.Tests/TestProcessWrapperTest.cs
@@ -17,13 +17,12 @@ public class TestProcessWrapperTest
 
         _testProcessBuilderFactory = new Mock<ITestProcessBuilderFactory>();
         _testProcessBuilderFactory
-            .Setup(
-                x =>
-                    x.CreateBuilder(
-                        It.IsAny<string>(),
-                        It.IsAny<BuildConfiguration>(),
-                        It.IsAny<bool>()
-                    )
+            .Setup(x =>
+                x.CreateBuilder(
+                    It.IsAny<string>(),
+                    It.IsAny<BuildConfiguration>(),
+                    It.IsAny<bool>()
+                )
             )
             .Returns(testProcessBuilder.Object);
 

--- a/TestProcessWrapper.sln
+++ b/TestProcessWrapper.sln
@@ -32,6 +32,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TestProcessWrapper.Nupkg.Te
 		TestProcessWrapper.Nupkg.Tests\.gitignore = TestProcessWrapper.Nupkg.Tests\.gitignore
 		TestProcessWrapper.Nupkg.Tests\net6.0-global.json = TestProcessWrapper.Nupkg.Tests\net6.0-global.json
 		TestProcessWrapper.Nupkg.Tests\net7.0-global.json = TestProcessWrapper.Nupkg.Tests\net7.0-global.json
+		TestProcessWrapper.Nupkg.Tests\net8.0-global.json = TestProcessWrapper.Nupkg.Tests\net8.0-global.json
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestProcessWrapper.Unit.Tests", "TestProcessWrapper.Unit.Tests\TestProcessWrapper.Unit.Tests.csproj", "{7BC3300D-4599-409C-9839-A69E6E66CD7F}"

--- a/TestProcessWrapper/ProcessIdReader.cs
+++ b/TestProcessWrapper/ProcessIdReader.cs
@@ -24,9 +24,8 @@ internal class ProcessIdReader
 
         var processIdStartIndex = processOutput.IndexOf("Process ID", StringComparison.Ordinal);
         var newLineAfterProcessIdIndex = processOutput.IndexOf(
-            "\n",
-            processIdStartIndex,
-            StringComparison.Ordinal
+            '\n',
+            processIdStartIndex
         );
         var processIdNumberOfDigits = newLineAfterProcessIdIndex - processIdStartIndex - 10;
         var processIdString = processOutput.Substring(

--- a/TestProcessWrapper/ProcessIdReader.cs
+++ b/TestProcessWrapper/ProcessIdReader.cs
@@ -23,10 +23,7 @@ internal class ProcessIdReader
         }
 
         var processIdStartIndex = processOutput.IndexOf("Process ID", StringComparison.Ordinal);
-        var newLineAfterProcessIdIndex = processOutput.IndexOf(
-            '\n',
-            processIdStartIndex
-        );
+        var newLineAfterProcessIdIndex = processOutput.IndexOf('\n', processIdStartIndex);
         var processIdNumberOfDigits = newLineAfterProcessIdIndex - processIdStartIndex - 10;
         var processIdString = processOutput.Substring(
             processIdStartIndex + 10,

--- a/TestProcessWrapper/TestProcessBuilder.cs
+++ b/TestProcessWrapper/TestProcessBuilder.cs
@@ -72,7 +72,9 @@ internal abstract class TestProcessBuilder
         BuildConfiguration buildConfiguration
     )
     {
-        #if NET7_0_OR_GREATER
+        #if NET8_0_OR_GREATER
+            var binFolder = Path.Combine("bin", buildConfiguration.ToString(), "net8.0");
+        #elif NET7_0_OR_GREATER
             var binFolder = Path.Combine("bin", buildConfiguration.ToString(), "net7.0");
         #else
             var binFolder = Path.Combine("bin", buildConfiguration.ToString(), "net6.0");

--- a/TestProcessWrapper/TestProcessBuilder.cs
+++ b/TestProcessWrapper/TestProcessBuilder.cs
@@ -72,13 +72,13 @@ internal abstract class TestProcessBuilder
         BuildConfiguration buildConfiguration
     )
     {
-        #if NET8_0_OR_GREATER
-            var binFolder = Path.Combine("bin", buildConfiguration.ToString(), "net8.0");
-        #elif NET7_0_OR_GREATER
-            var binFolder = Path.Combine("bin", buildConfiguration.ToString(), "net7.0");
-        #else
-            var binFolder = Path.Combine("bin", buildConfiguration.ToString(), "net6.0");
-        #endif
+#if NET8_0_OR_GREATER
+        var binFolder = Path.Combine("bin", buildConfiguration.ToString(), "net8.0");
+#elif NET7_0_OR_GREATER
+        var binFolder = Path.Combine("bin", buildConfiguration.ToString(), "net7.0");
+#else
+        var binFolder = Path.Combine("bin", buildConfiguration.ToString(), "net6.0");
+#endif
 
         var processStartInfo = new ProcessStartInfo(processName)
         {

--- a/TestProcessWrapper/TestProcessWrapper.csproj
+++ b/TestProcessWrapper/TestProcessWrapper.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
         <PackageId>Boos.TestProcessWrapper</PackageId>
         <Version>0.0.0-alpha</Version>
         <title>TestProcessWrapper</title>

--- a/docs/add_dotnet_framework.adoc
+++ b/docs/add_dotnet_framework.adoc
@@ -1,0 +1,46 @@
+= Add Support for a New .NET Framework
+
+The following checklist contains all changes required to add support for a new .NET framework. Please uncheck all checkboxes before adding a new framework. Tick them off while performing the steps. The list is sorted by type of change, not necessarily by sequence of action.
+
+NOTE: A framework and language upgrade may bring additional or more strict static analysis checks. If you encounter new static analysis errors, then fix them in separate commits after the framework upgrade commit.
+
+== Verify completeness of checklist
+
+To verify that this checklist is complete, perform the following checks. Add newly discovered tasks to the sections below.
+
+- [x] Search all files of the repository for "net6"
+- [x] Take a look at the commits of the recently added .net framework. Use git blame and git log for one of the files listed below to find all relevant commits.
+
+== Increase the minor version number in
+
+- [x] .github/workflows/dotnet.yml
+- [x] CHANGELOG.md
+
+== Update the framework in
+
+- [x] smoketest.sh
+- [x] TestProcessWrapper.csproj
+- [x] TestProcessWrapper.Acceptance.Tests.csproj
+- [x] TestProcessWrapper.LongLived.Application.csproj
+- [x] TestProcessWrapper.ShortLived.Application.csproj
+- [x] TestProcessWrapper.Unit.Tests.csproj
+- [x] .github/workflows/dotnet.yml
+
+== Document the changes in
+
+- [x] CHANGELOG.md
+- [x] README.md
+
+== Other changes
+
+- [x] Add another net?.0-global.json to the folder TestProcessWrapper.Nupkg.Tests
+- [x] Include the new net?.0-global.json into TestProcessWrapper.sln
+- [x] Extend the TestProcessBuilder.CreateProcessStartInfo method to consider the new framework version; The constant NET8_0_OR_GREATER is a https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/preprocessor-directives[.NET language feature].
+
+== Test
+
+- [x] Verify that the target .NET SDK is installed using `dotnet --list-sdks`
+- [ ] Execute the `./build/build.sh` script
+- [ ] Run the smoke test (see README.md)
+- [ ] Load solution and build all in your IDE
+- [ ] Run all tests in your IDE

--- a/docs/add_dotnet_framework.adoc
+++ b/docs/add_dotnet_framework.adoc
@@ -40,7 +40,7 @@ To verify that this checklist is complete, perform the following checks. Add new
 == Test
 
 - [x] Verify that the target .NET SDK is installed using `dotnet --list-sdks`
-- [ ] Execute the `./build/build.sh` script
-- [ ] Run the smoke test (see README.md)
-- [ ] Load solution and build all in your IDE
-- [ ] Run all tests in your IDE
+- [x] Execute the `./build/build.sh` script
+- [x] Run the smoke test for all supported .NET versions (see README.md)
+- [x] Load solution and build all in your IDE
+- [x] Run all tests in your IDE


### PR DESCRIPTION
### Added

- Add support for net8.0 while keeping support for net6.0 and net7.0

### Changed

- Fix new .NET 8 static analysis warnings regarding performance of string operations
  - CA1865: Use 'string.Method(char)' instead of 'string.Method(string)' for string with single char
  - CA1862: Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
- Upgrade coveralls build action to v2